### PR TITLE
fix cc + makefile + readme

### DIFF
--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -6,7 +6,24 @@ COPY Cargo.toml Cargo.lock /workspace/
 
 RUN mkdir src && touch src/lib.rs
 
-RUN cargo build --release
+RUN touch /rust_target.txt /apt_deps.txt /cc.txt /rust_flags.txt /ar.txt
+
+ARG TARGETPLATFORM
+RUN case "$TARGETPLATFORM" in \
+  "linux/amd64") echo x86_64-unknown-linux-gnu > /rust_target.txt && \
+  		 echo gcc-x86-64-linux-gnu >> /apt_deps.txt && \
+		 echo x86_64-linux-gnu-gcc >> /cc.txt && \
+		 echo '-C linker=x86_64-linux-gnu-gcc' >> /rust_flags.txt && \
+		 echo x86_64-linux-gnu-ar >> /ar.txt ;; \
+  "linux/arm64") echo aarch64-unknown-linux-gnu > /rust_target.txt ;; \
+  *) echo "$TARGETPLATFORM" && exit 1 ;; \
+esac
+
+RUN apt-get update && (cat /apt_deps.txt | xargs apt-get install -y)
+
+RUN rustup target add $(cat /rust_target.txt)
+
+RUN RUSTFLAGS=$(cat /rust_flags.txt) TARGET_CC=$(cat /cc.txt) TARGET_AR=$(cat /ar.txt) cargo build --release --target $(cat /rust_target.txt)
 
 COPY src /workspace/src
 
@@ -14,11 +31,13 @@ COPY src /workspace/src
 RUN touch /workspace/src/lib.rs
 
 # This is the actual application build.
-RUN cargo build --release
+RUN RUSTFLAGS=$(cat /rust_flags.txt) TARGET_CC=$(cat /cc.txt) TARGET_AR=$(cat /ar.txt) cargo build --release --target $(cat /rust_target.txt)
 
-FROM --platform=${BUILDPLATFORM} debian:bullseye-slim
+RUN cp target/$(cat /rust_target.txt)/release/sidecar .
 
-COPY --from=builder /workspace/target/release/sidecar /usr/local/bin/sidecar
+FROM --platform=${TARGETPLATFORM} debian:bullseye-slim
+
+COPY --from=builder /workspace/sidecar /usr/local/bin/sidecar
 
 # TODO entrypoint to prevent execing
 CMD ["/usr/local/bin/sidecar"]

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,15 @@ all: build test format lint
 DOCKER_BINS := sidecar
 DOCKER_ORG := lekko
 
-# TODO: right now, we haven't worked out cross-compilation. We need to
-# generate images on the source machines.
-# DOCKER_BUILD_EXTRA_FLAGS=--platform=linux/arm64/v8
+ifneq (,$(findstring amd64,$(MAKECMDGOALS)))
+    DOCKER_BUILD_EXTRA_FLAGS := --platform=linux/amd64
+    DOCKER_EXTRA_TAG := amd64
+endif
+
+# TODO: check our local machine, right now this just runs on M1 Mac w/ Docker Desktop.
+DOCKER_BUILD_EXTRA_FLAGS ?= --platform=linux/arm64
+DOCKER_EXTRA_TAG ?= arm64
+
 
 define dockerbinfunc
 .PHONY: dockerbuilddeps$(1)
@@ -68,6 +74,9 @@ dockerbuild$(1): dockerbuilddeps$(1)
 	docker build $(DOCKER_BUILD_EXTRA_FLAGS) -t $(DOCKER_ORG)/$(1):latest -f Dockerfile.$(1) .
 ifdef EXTRA_DOCKER_ORG
 	docker tag $(DOCKER_ORG)/$(1):latest $(EXTRA_DOCKER_ORG)/$(1):latest
+endif
+ifdef DOCKER_EXTRA_TAG
+	docker tag $(DOCKER_ORG)/$(1):latest $(DOCKER_ORG)/$(1):$(DOCKER_EXTRA_TAG)
 endif
 
 dockerbuild:: dockerbuild$(1)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ cargo install protoc-gen-prost
 cargo install protoc-gen-prost-tonic
 buf generate --template buf.gen.yaml buf.build/lekkodev/cli
 ```
+
+### Building docker files
+
+Run:
+```
+make dockerbuild
+```
+Or if you want an image for amd64 run:
+```
+make dockerbuild amd64
+```
+
 ## Deploying
 
 Running the dockerfile for now:


### PR DESCRIPTION
When we run `make dockerbuild amd64` we still get the following error:
```
make: *** No rule to make target `amd64'.  Stop.
```

I wonder if there is a way around it
