### PR TITLE
Turn on proxy mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .parse::<Uri>()?;
 
     // Setting proxy_mode to false will ensure that we perform rules evaluation locally in the sidecar.
-    let proxy_mode = false;
+    let proxy_mode = true;
     println!("lekko address: {}\nProxy mode: {}", lekko_addr, proxy_mode);
 
     let http_client = hyper::Client::builder().build(


### PR DESCRIPTION
GetJSONValue is currently broken, because the server is supposed to convert the evaluated 
`Any` result to json encoded bytes. However, no working implementation of proto->json exists 
yet (specifically for the `Value` type in struct.proto).  prost does not yet support it. So 
until we can find a workaround, turn off local evaluation.
