### PR TITLE
Don't instantiate metrics in static mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
     let store = Store::new(dist_client.clone(), bootstrap_data);
-    let metrics = Metrics::new(dist_client);
+    let metrics = Metrics::new(dist_client, args.mode);
     let service = ConfigurationServiceServer::new(Service {
         shutdown_tx: Mutex::new(Some(shutdown_tx)),
         config_client,


### PR DESCRIPTION
Stop sidecar from sending metrics when running in `Static` mode

```
error handling send flag evaluation future Status { code: Unauthenticated, message: "check api key: invalid api key, incorrect format", details: b"\x08\x10\x120check api key: invalid api key, incorrect format", metadata: MetadataMap { headers: {"server": "awselb/2.0", "date": "Tue, 25 Apr 2023 05:39:47 GMT", "content-type": "application/grpc", "grpc-accept-encoding": "gzip", "grpc-encoding": "gzip", "trailer": "Grpc-Status", "trailer": "Grpc-Message", "trailer": "Grpc-Status-Details-Bin"} }, source: None }
```