### PR TITLE
Update bucketing function salt parameters

### DIFF
--- a/src/evaluate/evaluator.rs
+++ b/src/evaluate/evaluator.rs
@@ -15,9 +15,8 @@ use super::rules_v3::check_rule as check_rule_v3;
 // Information required to evaluate rules but not part of the feature's
 // context.
 pub struct EvalContext {
-    pub owner_name: String,
-    pub repo_name: String,
     pub namespace: String,
+    pub feature_name: String,
 }
 
 // Performs evaluation of the feature tree using the given context.

--- a/src/service.rs
+++ b/src/service.rs
@@ -57,9 +57,8 @@ impl Service {
             )));
         }
         let eval_context = EvalContext {
-            owner_name: feature.rk.owner_name.to_owned(),
-            repo_name: feature.rk.repo_name.to_owned(),
             namespace: feature.namespace.to_owned(),
+            feature_name: feature_data.feature.key.to_owned(),
         };
         let eval_result = evaluate(&feature_data.feature, context, &eval_context)?;
         if let Some(m) = self.metrics.as_ref() {


### PR DESCRIPTION
# Context
See overall [task](https://www.notion.so/lekko/Implement-bucket-function-rule-evaluation-6c795242061e4fdba3ed4717d369d491?pvs=4)

In #39, we started using the owner name -> repo name -> namespace as "salting parameters" for the bucket's hashing algorithm to guarantee repo-wide consistent but randomized bucketing behavior. But in the CLI, we discovered it's very hacky to extract the team/owner/repo info from the git repo being used and after some discussion, decided to move to using namespace -> feature name -> context key instead.

# Details
- Updated `EvalContext` to remove owner/repo names and add feature name
- Updated bucket evaluator to use appropriate fields
- Updated unit tests