### PR TITLE
Add grpc health check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,6 +2444,7 @@ dependencies = [
  "sha1",
  "tokio",
  "tonic",
+ "tonic-health",
  "tower",
  "tower-http",
  "tracing",
@@ -2749,6 +2750,19 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080964d45894b90273d2b1dd755fdd114560db8636bb41cea615213c45043c4d"
+dependencies = [
+ "async-stream",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -20,6 +20,7 @@ serde = "1"
 serde_json = "1"
 tokio = { version="1.0", features=["rt", "rt-multi-thread", "macros", "time", "sync", "signal"] }
 tonic = { version= "0.9", features=["tls", "gzip"]}
+tonic-health = "0.9.2"
 tower = "0.4"
 tower-http = { version="0.4", features=["trace"] }
 tracing = "0.1"


### PR DESCRIPTION
Add health check to enable probe checks: https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/#introducing-grpc-health-probe

Test
```
grpc-health-probe --addr 0.0.0.0:50051
status: SERVING
```