### PR TITLE
Register in default mode if api key is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,8 @@ dockerbuilddeps$(1)::
 
 .PHONY: dockerbuildlocal$(1)
 dockerbuildlocal$(1): dockerbuilddeps$(1)
-	$(eval TAG := $(shell git describe --abbrev=0 --tags))
-	$(eval GIT_HASH := $(shell git rev-parse HEAD))
-	docker build -t $(DOCKER_ORG)/$(1):latest --build-arg SIDECAR_VERSION=$(TAG) --build-arg SIDECAR_GIT_COMMIT=$(GIT_HASH) -f Dockerfile.$(1) .
-	
+	docker build -t $(DOCKER_ORG)/$(1):latest -f Dockerfile.$(1) .
+
 .PHONY: dockerbuild$(1)
 dockerbuild$(1): dockerbuilddeps$(1)
 	docker build -t $(DOCKER_REMOTE)/$(DOCKER_ORG)/$(1):amd64 -f Dockerfile.$(1) --platform=linux/amd64 .


### PR DESCRIPTION
also pass sidecar version when registering (as "{version}_{commit}"

Test Plan:
run locally on both static and default modes and check registration table in the db
tested the following cases:
- static, correct remote url -> works correctly, uses session
- static, wrong remote url -> still works
- default, correct remote url -> works
- default, wrong remote url -> panics

static
```
❯ : cargo run --release -p sidecar -- --repo-path /Users/sergey/repos/example --mode static --api-key lekko_c7639 --bind-addr 127.0.0.1:50051 --lekko-addr https://prod.api.lekko.dev
```
default
```
❯ : cargo run --release -p sidecar -- --repo-url lekkodev/example --mode default --api-key lekko_c7639 --bind-addr 127.0.0.1:50051 --lekko-addr https://prod.api.lekko.dev
```
db:
```
dev/|⚠ main ⚠|> select * from distribution_sessions order by created_at desc limit 5\G
*************************** 1. row ***************************
          session_key: 73201f32-1d03-4836-b492-c1fb360035c9
        repository_id: 109
initial_bootstrap_sha: 2845ea838d4818e4dac4f447f262196cbeeaf940
      sidecar_version: sergey_test_cf6e71bbe1d49a0030f4e6c1f18a2084226b1915
           created_at: 2023-07-21 23:17:23
           namespaces: 0x6E756C6C
            closed_at: NULL
*************************** 2. row ***************************
          session_key: ca575d4a-aade-4b6e-91a5-1e6e56e8f6d5
        repository_id: 109
initial_bootstrap_sha: 5cf29c16f15d92f03b183ef5d9533d2a8ab45a25
      sidecar_version: sergey_test_cf6e71bbe1d49a0030f4e6c1f18a2084226b1915
           created_at: 2023-07-21 23:17:04
           namespaces: 0x6E756C6C
            closed_at: NULL
*************************** 3. row ***************************
          session_key: cd09aea1-f5a1-4f7f-ab10-e38279108763
        repository_id: 109
initial_bootstrap_sha: 5cf29c16f15d92f03b183ef5d9533d2a8ab45a25
      sidecar_version: sergey_test_cf6e71bbe1d49a0030f4e6c1f18a2084226b1915
           created_at: 2023-07-21 23:00:37
           namespaces: 0x6E756C6C
            closed_at: NULL
```
