### PR TITLE
Infer git sha from git-sync symlink

### DIFF
--- a/sidecar/src/types.rs
+++ b/sidecar/src/types.rs
@@ -161,7 +161,7 @@ mod tests {
 
         let cc = ConnectionCredentials {
             session_key: "".to_string(),
-            repo_key: rk.clone(),
+            repo_key: rk,
             api_key: AsciiMetadataValue::from_static("some"),
         };
         let new_req = override_api_key(req, &Some(cc));
@@ -189,7 +189,7 @@ mod tests {
 
         let cc = ConnectionCredentials {
             session_key: "".to_string(),
-            repo_key: rk.clone(),
+            repo_key: rk,
             api_key: AsciiMetadataValue::from_static("some"),
         };
         let new_req = override_api_key(req, &Some(cc));


### PR DESCRIPTION
We have to special case git-sync. When new updates come in, it does not update the `.git` directory to reflect the updated contents. Therefore we cannot rely on the `.git` directory. Instead, we rely on the name of the symlinked folder. By convention, this folder is always named with the commit hash and that is what we need.